### PR TITLE
Omit limit clause when limit is zero

### DIFF
--- a/lib/job_board/app.rb
+++ b/lib/job_board/app.rb
@@ -48,7 +48,7 @@ module JobBoard
       param :infra, String, blank: true, required: true
       param :name, String, blank: true
       param :tags, Hash, default: {}
-      param :limit, Integer, default: 1
+      param :limit, Integer, default: 0
       param :is_default, Boolean, default: false
 
       images = JobBoard::Services::FetchImages.run(params: params)

--- a/lib/job_board/services/fetch_images.rb
+++ b/lib/job_board/services/fetch_images.rb
@@ -19,9 +19,7 @@ module JobBoard
       def run
         images = []
 
-        build_query.reverse_order(:created_at).limit(
-          params.fetch('limit')
-        ).each do |image|
+        build_query.each do |image|
           images << image.tap do |i|
             i['tags'] = i['tags'].to_hash if i['tags']
           end
@@ -33,13 +31,16 @@ module JobBoard
       private
 
       def build_query
-        with_tags_matching(
+        query = with_tags_matching(
           with_name_like(
             with_is_default(
               JobBoard::Models::Image.where(infra: infra)
             )
           )
-        )
+        ).reverse_order(:created_at)
+        limit = params.fetch('limit', 1)
+        query = query.limit(limit) unless limit.zero?
+        query
       end
 
       def with_is_default(image_query)

--- a/lib/job_board/services/fetch_images.rb
+++ b/lib/job_board/services/fetch_images.rb
@@ -38,7 +38,7 @@ module JobBoard
             )
           )
         ).reverse_order(:created_at)
-        limit = params.fetch('limit', 1)
+        limit = params.fetch('limit', 0)
         query = query.limit(limit) unless limit.zero?
         query
       end

--- a/spec/integration/images_api_spec.rb
+++ b/spec/integration/images_api_spec.rb
@@ -34,20 +34,20 @@ describe 'Images API', integration: true do
     end
 
     {
-      'with infra' => ['/images?infra=test&limit=10', 3],
+      'with infra' => ['/images?infra=test&limit=0', 3],
       'with infra & default limit' => ['/images?infra=test', 1],
       'with infra & name' =>
-        ['/images?infra=test&name=test-image-0&limit=10', 1],
+        ['/images?infra=test&name=test-image-0&limit=0', 1],
       'with infra & name regex' =>
-        ['/images?infra=test&name=test-.*&limit=10', 3],
+        ['/images?infra=test&name=test-.*&limit=0', 3],
       'with nonmatched conditions' =>
-        ['/images?infra=test&name=foo&limit=10', 0],
+        ['/images?infra=test&name=foo&limit=0', 0],
       'with infra & tags production:yep' =>
-        ['/images?infra=test&tags=production:yep&limit=10', 1],
+        ['/images?infra=test&tags=production:yep&limit=0', 1],
       'with infra & tags production:nope' =>
-        ['/images?infra=test&tags=production:nope&limit=10', 2],
+        ['/images?infra=test&tags=production:nope&limit=0', 2],
       'with infra & tags foo:bar' =>
-        ['/images?infra=test&tags=foo:bar&limit=10', 3]
+        ['/images?infra=test&tags=foo:bar&limit=0', 3]
     }.each do |desc, (path, count)|
       context desc do
         it 'returns 200' do
@@ -359,7 +359,7 @@ describe 'Images API', integration: true do
         ['/images?infra=test&name=test-image-0&limit=10', 204],
       'with infra, name, & tags production:yep' =>
         ['/images?infra=test&name=test-image-0' \
-         '&tags=production:yep&limit=10', 204]
+         '&tags=production:yep&limit=0', 204]
     }.each do |desc, (path, status)|
       context desc do
         it "returns #{status}" do

--- a/spec/integration/images_api_spec.rb
+++ b/spec/integration/images_api_spec.rb
@@ -34,20 +34,20 @@ describe 'Images API', integration: true do
     end
 
     {
-      'with infra' => ['/images?infra=test&limit=0', 3],
-      'with infra & default limit' => ['/images?infra=test', 1],
+      'with infra' => ['/images?infra=test', 3],
+      'with infra & default limit' => ['/images?infra=test', 3],
       'with infra & name' =>
-        ['/images?infra=test&name=test-image-0&limit=0', 1],
+        ['/images?infra=test&name=test-image-0', 1],
       'with infra & name regex' =>
-        ['/images?infra=test&name=test-.*&limit=0', 3],
+        ['/images?infra=test&name=test-.*', 3],
       'with nonmatched conditions' =>
-        ['/images?infra=test&name=foo&limit=0', 0],
+        ['/images?infra=test&name=foo', 0],
       'with infra & tags production:yep' =>
-        ['/images?infra=test&tags=production:yep&limit=0', 1],
+        ['/images?infra=test&tags=production:yep', 1],
       'with infra & tags production:nope' =>
-        ['/images?infra=test&tags=production:nope&limit=0', 2],
+        ['/images?infra=test&tags=production:nope', 2],
       'with infra & tags foo:bar' =>
-        ['/images?infra=test&tags=foo:bar&limit=0', 3]
+        ['/images?infra=test&tags=foo:bar', 3]
     }.each do |desc, (path, count)|
       context desc do
         it 'returns 200' do

--- a/spec/unit/services/fetch_images_spec.rb
+++ b/spec/unit/services/fetch_images_spec.rb
@@ -23,7 +23,8 @@ class FakeImageQuery
 end
 
 describe JobBoard::Services::FetchImages do
-  subject { described_class.new(params: { 'infra' => 'test' }) }
+  subject { described_class.new(params: params) }
+  let(:params) { { 'infra' => 'test' } }
   let(:image0) { build(:image) }
   let(:results) { build_list(:image, 3) }
 
@@ -62,6 +63,14 @@ describe JobBoard::Services::FetchImages do
 
       fetch_params = { 'infra' => 'test', 'limit' => 10 }
       expect(described_class.run(params: fetch_params)).to be_empty
+    end
+  end
+
+  context 'when limit is 0' do
+    let(:params) { { 'infra' => 'test', 'limit' => 0 } }
+
+    it 'builds a query without a limit clause' do
+      expect(subject.send(:build_query).sql.downcase).to_not include('limit')
     end
   end
 end


### PR DESCRIPTION
I decided to go with the `0 =~ unlimited` semantics because we're already enforcing the type of the `limit` param to be an Integer.