### PR TITLE
Delete non-existent images from dest on image sync (to staging)

### DIFF
--- a/script/sync-images
+++ b/script/sync-images
@@ -40,8 +40,10 @@ main() {
   local tmpdir
   tmpdir="$(mktemp -d /var/tmp/job-board-sync.XXXXX)"
 
-  __dump_src "${src}" "${infra}" "${tmpdir}"
-  __load_dest "${dest}" "${infra}" "${tmpdir}" "${filter}"
+  __dump_images "${src}"  "${infra}" "${tmpdir}/dump-src.json"
+  __dump_images "${dest}" "${infra}" "${tmpdir}/dump-dest.json"
+  __upsert_dest "${dest}" "${infra}" "${tmpdir}" "${filter}"
+  __delete_dest "${dest}" "${infra}" "${tmpdir}" "${filter}"
   exit 0
 }
 
@@ -56,29 +58,50 @@ __usage() {
     " <"${0}"
 }
 
-__dump_src() {
-  local src="${1}"
+__dump_images() {
+  local url="${1}"
   local infra="${2}"
-  local tmpdir="${3}"
+  local tmpfile="${3}"
 
-  echo "---> dumping to ${tmpdir}/dump.json"
-  curl -sSL "${src}/images?infra=${infra}" >"${tmpdir}/dump.json"
+  echo "---> dumping to ${tmpfile}"
+  curl -sSL "${url}/images?infra=${infra}" >"${tmpfile}"
 }
 
-__load_dest() {
+__upsert_dest() {
   local dest="${1}"
   local infra="${2}"
   local tmpdir="${3}"
   local filter="${4}"
 
-  echo "---> loading from ${tmpdir}/dump.json"
-  for args in $(__json_to_qs "${filter}" <"${tmpdir}/dump.json"); do
+  echo "---> loading from ${tmpdir}/dump-src.json"
+  for args in $(__json_to_qs "${filter}" <"${tmpdir}/dump-src.json"); do
     (
       echo "syncing ${args}"
       curl -fsSL -X PUT "${dest}/images?${args}" || (
         curl -fsSL -X POST "${dest}/images?${args}" \
           || echo "ERROR: failed to sync ${args}"
       )
+    ) 2>&1 | sed 's/^/     /'
+  done
+}
+
+__delete_dest() {
+  local dest="${1}"
+  local infra="${2}"
+  local tmpdir="${3}"
+  local filter="${4}"
+
+  echo "---> loading from ${tmpdir}/dump-dest.json"
+  for name in $(__json_to_name "${filter}" <"${tmpdir}/dump-dest.json"); do
+    (
+      local args="infra=${infra}&name=${name}"
+
+      if [ $(__json_by_infra_and_name "${infra}" "${name}" <"${tmpdir}/dump-src.json" | wc -l) -ne 0 ]; then
+        echo "${name} not found in src, deleting from dest ${args}"
+        curl -fsSL -X DELETE "${dest}/images?${args}" || (
+          echo "ERROR: failed to delete ${args}"
+        )
+      fi
     ) 2>&1 | sed 's/^/     /'
   done
 }
@@ -93,7 +116,19 @@ __json_to_qs() {
       "is_default=" + (.is_default | tostring),
       "tags=" + (.tags | to_entries | map(.key + ":" + .value) | join(","))
     ] | join("&")'
+}
 
+__json_to_name() {
+  local filter="${1}"
+
+  jq -r '.data[] | select(.name | test("'"${filter}"'")) | .name'
+}
+
+__json_by_infra_and_name() {
+  local infra="${1}"
+  local name="${2}"
+
+  jq -r '.data[] | select(.infra == "'"${infra}"'") | select(.name == "'"${name}"'")'
 }
 
 __ensure_jq() {


### PR DESCRIPTION
We periodically run the sync-images script (as a heroku scheduler job) that syncs all image changes from production to staging. However, this script only performs PUT and POST. There is no DELETE.

The consequence is that we have lots of old images on staging that no longer exist in production or on GCE. They have already been deleted by gcloud-cleanup. That then causes builds to no longer start (on staging), and cycle between created/queued states.

This patch makes sure we perform a DELETE for those images, to truly keep staging in sync with production.