### PR TITLE
Remove leading `builds\.` from incoming queue names

### DIFF
--- a/lib/job_board/job_delivery_api.rb
+++ b/lib/job_board/job_delivery_api.rb
@@ -35,6 +35,7 @@ module JobBoard
         )
       end
 
+      queue = params[:queue].to_s.sub(/^builds\./, '')
       from = request.env.fetch('HTTP_FROM')
       site = request.env.fetch('travis.site')
 
@@ -42,13 +43,13 @@ module JobBoard
         count: params[:count],
         from: from,
         jobs: JSON.parse(request.body.read).fetch('jobs'),
-        queue_name: params[:queue],
+        queue_name: queue,
         site: site
       ).merge(
         '@count' => params[:count],
-        '@queue' => params[:queue]
+        '@queue' => queue
       )
-      log msg: :allocated, queue: params[:queue],
+      log msg: :allocated, queue: queue,
           count: params[:count], from: from, site: site
       json body
     end

--- a/lib/job_board/job_queue_reconciler.rb
+++ b/lib/job_board/job_queue_reconciler.rb
@@ -72,8 +72,11 @@ module JobBoard
       claims.each do |job_id, claimer|
         next unless worker == claimer
         redis.multi do |conn|
+          conn.srem("worker:#{site}:#{worker}:idx", job_id)
+          conn.lrem("worker:#{site}:#{worker}", 1, job_id)
           conn.lpush("queue:#{site}:#{queue_name}", job_id)
           conn.hdel("queue:#{site}:#{queue_name}:claims", job_id)
+          conn.hdel("queue:#{site}:#{queue_name}:claims:timestamps", job_id)
           reclaimed += 1
         end
       end


### PR DESCRIPTION
So that the same queue name can be used in worker for both AMQP and HTTP queue types.  Related: https://github.com/travis-ci/worker/pull/312