### PR TITLE
Remove workers from worker sets on cleanup

### DIFF
--- a/lib/job_board.rb
+++ b/lib/job_board.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'time'
+
 require_relative 'travis'
 
 require 'connection_pool'

--- a/lib/job_board/job_queue.rb
+++ b/lib/job_board/job_queue.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'time'
+
 require 'job_board'
 
 module JobBoard
@@ -87,6 +89,7 @@ module JobBoard
           conn.sadd('sites', site)
           conn.sadd("queues:#{site}", queue_name)
           conn.sadd("workers:#{site}", worker)
+          conn.setex("workers:#{site}:#{worker}:ping", ttl, Time.now.iso8601)
         end
       end
     end

--- a/lib/job_board/job_queue.rb
+++ b/lib/job_board/job_queue.rb
@@ -89,7 +89,7 @@ module JobBoard
           conn.sadd('sites', site)
           conn.sadd("queues:#{site}", queue_name)
           conn.sadd("workers:#{site}", worker)
-          conn.setex("workers:#{site}:#{worker}:ping", ttl, Time.now.iso8601)
+          conn.setex("worker:#{site}:#{worker}:ping", ttl, Time.now.iso8601)
         end
       end
     end

--- a/lib/job_board/job_queue_reconciler.rb
+++ b/lib/job_board/job_queue_reconciler.rb
@@ -28,7 +28,7 @@ module JobBoard
           reclaimed, claimed = reconcile_site!(redis: redis, site: site)
           stats[:sites][site][:capacity] = {
             total: measure_capacity(redis: redis, site: site),
-            busy: claimed.select { |_, w| w[:claimed].positive? }.length
+            busy: claimed.count { |_, w| w[:claimed].positive? }
           }
 
           JobBoard.logger.info('reclaimed jobs', site: site, n: reclaimed.length)

--- a/lib/job_board/job_queue_reconciler.rb
+++ b/lib/job_board/job_queue_reconciler.rb
@@ -57,7 +57,7 @@ module JobBoard
           reclaimed += reclaim_jobs_from_worker(
             redis: redis, site: site, worker: worker
           )
-          claimed[worker] = { claimed: 0 }
+          redis.srem("workers:#{site}", worker)
         end
       end
 

--- a/spec/integration/job_queue_reconciler_spec.rb
+++ b/spec/integration/job_queue_reconciler_spec.rb
@@ -52,8 +52,7 @@ describe JobBoard::JobQueueReconciler do
         expect(stats[:sites][site.to_sym]).to eq(
           workers: {
             'a' => { claimed: 2 },
-            'b' => { claimed: 2 },
-            'c' => { claimed: 0 }
+            'b' => { claimed: 2 }
           },
           queues: {
             'lel' => { queued: 0, claimed: 4 }
@@ -86,8 +85,7 @@ describe JobBoard::JobQueueReconciler do
         expect(stats[:sites][site.to_sym]).to eq(
           workers: {
             'a' => { claimed: 2 },
-            'b' => { claimed: 1 },
-            'c' => { claimed: 0 }
+            'b' => { claimed: 1 }
           },
           queues: {
             'lel' => { queued: 1, claimed: 3 }
@@ -124,9 +122,7 @@ describe JobBoard::JobQueueReconciler do
         expect(stats[:sites][site.to_sym]).to_not be_nil
         expect(stats[:sites][site.to_sym]).to eq(
           workers: {
-            'a' => { claimed: 0 },
-            'b' => { claimed: 2 },
-            'c' => { claimed: 0 }
+            'b' => { claimed: 2 }
           },
           queues: {
             'lel' => { queued: 2, claimed: 2 }

--- a/spec/integration/job_queue_reconciler_spec.rb
+++ b/spec/integration/job_queue_reconciler_spec.rb
@@ -52,7 +52,8 @@ describe JobBoard::JobQueueReconciler do
         expect(stats[:sites][site.to_sym]).to eq(
           workers: {
             'a' => { claimed: 2 },
-            'b' => { claimed: 2 }
+            'b' => { claimed: 2 },
+            'c' => { claimed: 0 }
           },
           queues: {
             'lel' => { queued: 0, claimed: 4 }
@@ -89,7 +90,8 @@ describe JobBoard::JobQueueReconciler do
         expect(stats[:sites][site.to_sym]).to eq(
           workers: {
             'a' => { claimed: 2 },
-            'b' => { claimed: 1 }
+            'b' => { claimed: 1 },
+            'c' => { claimed: 0 }
           },
           queues: {
             'lel' => { queued: 1, claimed: 3 }
@@ -121,6 +123,7 @@ describe JobBoard::JobQueueReconciler do
         # the worker queue and index ~meatballhat
         JobBoard.redis.del("worker:#{site}:a:idx")
         JobBoard.redis.del("worker:#{site}:a")
+        JobBoard.redis.del("worker:#{site}:a:ping")
       end
 
       it 'reconciles' do
@@ -130,7 +133,8 @@ describe JobBoard::JobQueueReconciler do
         expect(stats[:sites][site.to_sym]).to_not be_nil
         expect(stats[:sites][site.to_sym]).to eq(
           workers: {
-            'b' => { claimed: 2 }
+            'b' => { claimed: 2 },
+            'c' => { claimed: 0 }
           },
           queues: {
             'lel' => { queued: 2, claimed: 2 }
@@ -138,7 +142,7 @@ describe JobBoard::JobQueueReconciler do
           reclaimed: 2,
           capacity: {
             busy: 1,
-            total: 3
+            total: 2
           }
         )
         avail_a = job_queue.check_claims(

--- a/spec/integration/job_queue_reconciler_spec.rb
+++ b/spec/integration/job_queue_reconciler_spec.rb
@@ -57,7 +57,11 @@ describe JobBoard::JobQueueReconciler do
           queues: {
             'lel' => { queued: 0, claimed: 4 }
           },
-          reclaimed: 0
+          reclaimed: 0,
+          capacity: {
+            busy: 2,
+            total: 3
+          }
         )
         avail_a = job_queue.check_claims(
           worker: 'a', job_ids: %w[0 2]
@@ -90,7 +94,11 @@ describe JobBoard::JobQueueReconciler do
           queues: {
             'lel' => { queued: 1, claimed: 3 }
           },
-          reclaimed: 0
+          reclaimed: 0,
+          capacity: {
+            busy: 2,
+            total: 3
+          }
         )
         avail_a = job_queue.check_claims(
           worker: 'a', job_ids: %w[0 2]
@@ -127,7 +135,11 @@ describe JobBoard::JobQueueReconciler do
           queues: {
             'lel' => { queued: 2, claimed: 2 }
           },
-          reclaimed: 2
+          reclaimed: 2,
+          capacity: {
+            busy: 1,
+            total: 3
+          }
         )
         avail_a = job_queue.check_claims(
           worker: 'a', job_ids: %w[0 2]


### PR DESCRIPTION
since workers will re-register whenever re-allocating, plus report capacity.