### PR TITLE
Accept explicit capacity value from workers

### DIFF
--- a/lib/job_board/services/allocate_jobs.rb
+++ b/lib/job_board/services/allocate_jobs.rb
@@ -7,8 +7,8 @@ module JobBoard
     class AllocateJobs
       extend Service
 
-      def initialize(jobs: [], count: 1, from: '', queue_name: '', site: '')
-        @count = Integer(count)
+      def initialize(jobs: [], capacity: 1, from: '', queue_name: '', site: '')
+        @capacity = Integer(capacity)
         @from = from.to_s
         @jobs = Array(jobs)
         @job_queue = JobBoard::JobQueue.new(
@@ -17,12 +17,12 @@ module JobBoard
         )
       end
 
-      attr_reader :jobs, :count, :from, :job_queue
+      attr_reader :jobs, :capacity, :from, :job_queue
 
       def run
-        job_queue.register(worker: from, capacity: count)
+        job_queue.register(worker: from, capacity: capacity)
         claimed = job_queue.check_claims(worker: from, job_ids: jobs)
-        max = count - claimed.length
+        max = capacity - claimed.length
         claimed += job_queue.claim(worker: from, max: max) if max.positive?
 
         {

--- a/spec/integration/job_delivery_api_spec.rb
+++ b/spec/integration/job_delivery_api_spec.rb
@@ -65,7 +65,7 @@ describe 'Job Delivery API', integration: true do
 
     it 'rejects guest auth' do
       authorize(*guest_auth)
-      post '/jobs?queue=lel&count=3', JSON.dump(jobs: []),
+      post '/jobs?queue=lel&capacity=3', JSON.dump(jobs: []),
            'HTTP_CONTENT_TYPE' => 'application/json',
            'HTTP_FROM' => from,
            'HTTP_TRAVIS_SITE' => site
@@ -74,26 +74,26 @@ describe 'Job Delivery API', integration: true do
 
     it 'returns 200' do
       authorize(*admin_auth)
-      post '/jobs?queue=lel&count=3', JSON.dump(jobs: []),
+      post '/jobs?queue=lel&capacity=3', JSON.dump(jobs: []),
            'HTTP_CONTENT_TYPE' => 'application/json',
            'HTTP_FROM' => from,
            'HTTP_TRAVIS_SITE' => site
       expect(last_response.status).to eq(200)
     end
 
-    it 'includes count metadata' do
+    it 'includes capacity metadata' do
       authorize(*admin_auth)
-      post '/jobs?queue=lel&count=3', JSON.dump(jobs: []),
+      post '/jobs?queue=lel&capacity=3', JSON.dump(jobs: []),
            'HTTP_CONTENT_TYPE' => 'application/json',
            'HTTP_FROM' => from,
            'HTTP_TRAVIS_SITE' => site
       response_body = JSON.parse(last_response.body)
-      expect(response_body['@count']).to eq(3)
+      expect(response_body['@capacity']).to eq(3)
     end
 
     it 'includes queue metadata' do
       authorize(*admin_auth)
-      post '/jobs?queue=lel&count=3', JSON.dump(jobs: []),
+      post '/jobs?queue=lel&capacity=3', JSON.dump(jobs: []),
            'HTTP_CONTENT_TYPE' => 'application/json',
            'HTTP_FROM' => from,
            'HTTP_TRAVIS_SITE' => site
@@ -103,7 +103,7 @@ describe 'Job Delivery API', integration: true do
 
     it 'returns the expected number of jobs' do
       authorize(*admin_auth)
-      post '/jobs?queue=lel&count=3', JSON.dump(jobs: []),
+      post '/jobs?queue=lel&capacity=3', JSON.dump(jobs: []),
            'HTTP_CONTENT_TYPE' => 'application/json',
            'HTTP_FROM' => from,
            'HTTP_TRAVIS_SITE' => site
@@ -226,7 +226,7 @@ describe 'Job Delivery API', integration: true do
       )
 
       JobBoard::Services::AllocateJobs.run(
-        count: 1,
+        capacity: 1,
         from: from,
         jobs: [],
         queue_name: 'lel',


### PR DESCRIPTION
instead of overloading the term `count`