### PR TITLE
Account for current travis-worker state update body in specs

### DIFF
--- a/spec/integration/worker_interaction_spec.rb
+++ b/spec/integration/worker_interaction_spec.rb
@@ -147,12 +147,13 @@ describe 'Worker Interaction', integration: true do
 
   it 'marks jobs completed only when completed' do
     state_summary = misc_http_runner.state_summary
-    finished = state_summary.reject do |s|
-      s['data']['finished'] == '0001-01-01T00:00:00Z'
-    end
+    finished = state_summary.reject { |s| s['data']['finished_at'].nil? }
+
     expect(finished.length).to eq job_count
 
-    finished_timestamps = finished.map { |s| Time.parse(s['data']['finished']) }
+    finished_timestamps = finished.map do |s|
+      Time.parse(s['data']['finished_at'])
+    end
     finished_timestamps.sort!
 
     expect(finished_timestamps.min).to be > suite_start

--- a/spec/support/worker_runner.rb
+++ b/spec/support/worker_runner.rb
@@ -20,7 +20,7 @@ module Support
     private :workers
 
     def start(port: 9987, maybe_killer: true)
-      ensure_worker_exe_exists
+      ensure_fresh_worker_exe_exists
       n.times do |worker_n|
         workers[worker_n] = spawn_worker(worker_n, port)
       end
@@ -73,8 +73,8 @@ module Support
       end
     end
 
-    private def ensure_worker_exe_exists
-      return if File.exist?(worker_exe)
+    private def ensure_fresh_worker_exe_exists
+      return if fresh_exists?(worker_exe)
       FileUtils.mkdir_p(File.dirname(worker_exe))
 
       dl_out_file = File.join(tmproot, 'worker-download.out')
@@ -91,6 +91,11 @@ module Support
       end
 
       FileUtils.chmod(0o755, worker_exe)
+    end
+
+    private def fresh_exists?(path, max_age: 60 * 60 * 24)
+      return false unless File.exist?(path)
+      (Time.now - File.mtime(worker_exe)) < max_age
     end
 
     private def build_worker_env(worker_n, port)


### PR DESCRIPTION
and ensure the travis-worker binary in the spec tree is fresh