### PR TITLE
Include processor timeouts in responses

### DIFF
--- a/lib/job_board/config.rb
+++ b/lib/job_board/config.rb
@@ -75,6 +75,10 @@ module JobBoard
       log_parts_org_url: ENV.fetch('JOB_BOARD_LOG_PARTS_ORG_URL', ''),
       logger: { format_type: 'l2met', thread_id: true },
       paranoid_queues: ENV.fetch('JOB_BOARD_PARANOID_QUEUES', 'docker,ec2'),
+      processor_ttl: Integer(ENV.fetch('JOB_BOARD_PROCESSOR_TTL', '60')),
+      processor_pop_interval: Integer(
+        ENV.fetch('JOB_BOARD_PROCESSOR_POP_INTERVAL', '10')
+      ),
       reconcile_cutoff_seconds: 20,
       reconcile_purge_unknown_always: false,
       reconcile_purge_unknown_every: 42,
@@ -86,13 +90,7 @@ module JobBoard
         size: 5,
         timeout: 3
       },
-      sentry: { dsn: nil },
-      processor_ttl: Integer(
-        ENV.fetch(
-          'JOB_BOARD_PROCESSOR_TTL',
-          ENV.fetch('JOB_BOARD_WORKER_TTL', '10')
-        )
-      )
+      sentry: { dsn: nil }
     )
 
     default(access: [:key])

--- a/lib/job_board/job_delivery_api.rb
+++ b/lib/job_board/job_delivery_api.rb
@@ -21,6 +21,7 @@ module JobBoard
 
     before '/jobs*' do
       halt 403, JSON.dump('@type' => 'error', error: 'just no') if guest?
+      headers(interval_headers)
     end
 
     post '/jobs' do
@@ -164,6 +165,15 @@ module JobBoard
           request.env.fetch('REMOTE_ADDR', '???')
         )
       )
+    end
+
+    private def interval_headers
+      {
+        'Travis-Pop-Interval' => JobBoard.config.processor_pop_interval.to_s,
+        'Travis-Refresh-Claim-Interval' => Integer(
+          JobBoard.config.processor_ttl / 2
+        ).to_s
+      }
     end
   end
 end


### PR DESCRIPTION
so that processor load may be controlled in part by changing job-board's
configuration rather than rolling out config changes to workers.