### PR TITLE
Bump rack version to pick up security patches

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ GEM
       method_source (~> 0.9.0)
     public_suffix (3.0.3)
     puma (3.12.0)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-protection (2.0.4)
       rack
     rack-ssl (1.4.1)
@@ -146,4 +146,4 @@ DEPENDENCIES
   travis-logger!
 
 BUNDLED WITH
-   1.16.6
+   1.17.1


### PR DESCRIPTION
rack:
https://nvd.nist.gov/vuln/detail/CVE-2018-16470
https://nvd.nist.gov/vuln/detail/CVE-2018-16471