### PR TITLE
fixed jobs_images_updated_at_defaults check

### DIFF
--- a/db/verify/jobs_images_updated_at_defaults.sql
+++ b/db/verify/jobs_images_updated_at_defaults.sql
@@ -8,7 +8,8 @@ WHERE table_schema = 'job_board'
   AND table_name = 'jobs'
   AND column_name = 'updated_at'
   AND is_nullable = 'NO'
-  AND column_default = E'timezone(\'UTC\'::text, now())';
+  AND column_default = E'timezone(\'UTC\'::text, now())'
+  OR column_default = E'(now() AT TIME ZONE \'UTC\'::text)';
 
 SELECT 1/COUNT(*)
 FROM information_schema.columns
@@ -16,6 +17,7 @@ WHERE table_schema = 'job_board'
   AND table_name = 'images'
   AND column_name = 'updated_at'
   AND is_nullable = 'NO'
-  AND column_default = E'timezone(\'UTC\'::text, now())';
+  AND column_default = E'timezone(\'UTC\'::text, now())'
+  OR column_default = E'(now() AT TIME ZONE \'UTC\'::text)';
 
 ROLLBACK;


### PR DESCRIPTION
fixes + jobs_images_updated_at_defaults .. psql:db/verify/jobs_images_updated_at_defaults.sql:11: ERROR:  division by zero

column_default is:
`select column_default from information_schema.columns where table_schema='job_board' and table_name='jobs' and column_name='updated_at' and is_nullable='NO';
          column_default          
----------------------------------
 (now() AT TIME ZONE 'UTC'::text)
(1 row)
`